### PR TITLE
Release/v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Extended `qiskit` support to `2.0.0`
-  - Adjusted results object as the `header` instance is now changed to a dictionary. (Issue #41)  
+  - Adjusted results object as the `header` instance is now changed to a dictionary. (Issue #43)  
   - Relaxed `qiskit-aer` version to support `qiskit==2.0.0`. (Issue #41)
 - Adjusted internal API usage to align with changes in `some-core-lib@3.0.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Extended `qiskit` support to `2.0.0`
-  - Adjusted results object as the `header` instance is now changed to a dictionary. (Issue #43)  
-  - Relaxed `qiskit-aer` version to support `qiskit==2.0.0`. (Issue #41)
-- Adjusted internal API usage to align with changes in `some-core-lib@3.0.0`
+  - Adjusted results object as the `header` instance is now changed to a dictionary. (Issue [#43](https://github.com/moth-quantum/quantum-audio/issues/43))  
+  - Relaxed `qiskit-aer` version requirement to support latest `qiskit` version. (Issue [#41](https://github.com/moth-quantum/quantum-audio/issues/41))
 
 ### Notes
 - This release is backward-compatible with previous versions of `qiskit` between `1.1.0` to `2.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2025-04-16
+
+### Changed
+- Extended `qiskit` support to `2.0.0`
+  - Adjusted results object as the `header` instance is now changed to a dictionary. (Issue #41)  
+  - Relaxed `qiskit-aer` version to support `qiskit==2.0.0`. (Issue #41)
+- Adjusted internal API usage to align with changes in `some-core-lib@3.0.0`
+
+### Notes
+- This release is backward-compatible with previous versions of `qiskit` between `1.1.0` to `2.0.0`.
+

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ This project has been completely re-developed and is now maintained by <b>[Moth 
   
   - The License is updated from **MIT** to **Apache 2.0**
 
+> For changes in future versions, refer to [CHANGELOG.md](https://github.com/moth-quantum/quantum-audio/blob/main/CHANGELOG.md).
+
 ### Migration Guide
 If you're transitioning from the previous version, please check the [Migration Guide](https://github.com/moth-quantum/quantum-audio/blob/main/docs/guides/MIGRATION.md) for an overview of the package usability.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quantumaudio"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     {name = "Moth Quantum and collaborators", email = "qap.support@mothquantum.com"},
 ]

--- a/quantumaudio/__init__.py
+++ b/quantumaudio/__init__.py
@@ -17,7 +17,7 @@
 necessary utilities.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 import importlib
 from importlib.metadata import version
@@ -25,7 +25,7 @@ from packaging.version import parse
 
 # --------------------------- Qiskit Version Assertion ---------------------------
 
-_minimum_version = "1.0.0"
+_minimum_version = "1.1.0"
 _current_version = version("qiskit")
 
 if parse(_current_version) < parse(_minimum_version):


### PR DESCRIPTION
Prepared release for extended Qiskit support:
- Incremented MINOR version number from `0.1.0` to `0.2.0`.
- Incremented minimum `qiskit` version from `1.0.0` and `1.1.0`.
- Created `CHANGELOG.md`.
- Added reference to `CHANGELOG.md` in `README.md`.