### PR TITLE
fix(schemes): honour `execute_function` in `MSQPAM.decode`

### DIFF
--- a/quantumaudio/schemes/msqpam.py
+++ b/quantumaudio/schemes/msqpam.py
@@ -479,7 +479,7 @@ class MSQPAM(Scheme):
                 Array of decoded values
         """
         self.measure(circuit)
-        result = utils.execute(circuit=circuit, **kwargs)
+        result = execute_function(circuit=circuit, **kwargs)
         data = self.decode_result(
             result=result,
             metadata=metadata,

--- a/tests/test_msqpam.py
+++ b/tests/test_msqpam.py
@@ -476,3 +476,40 @@ def test_decode(
 
     print(f"errors: {errors}")
     assert np.mean(errors) < 0.1
+
+
+def test_decode_uses_execute_function(msqpam, monkeypatch):
+    # Regression test: `MSQPAM.decode` must invoke the supplied
+    # `execute_function` (rather than the default `utils.execute`) and forward
+    # `**kwargs` to it. The stub's returned `Result` must be the one passed on
+    # to `decode_result`.
+    canned_result = object()
+    sentinel = object()
+    execute_calls = []
+    decode_result_calls = []
+
+    def stub_execute(circuit, **kwargs):
+        execute_calls.append((circuit, kwargs))
+        return canned_result
+
+    def stub_decode_result(result, **kwargs):
+        decode_result_calls.append(result)
+        return sentinel
+
+    monkeypatch.setattr(msqpam, "decode_result", stub_decode_result)
+
+    encoded_circuit = msqpam.encode(test_inputs[0])
+    data = msqpam.decode(
+        encoded_circuit,
+        execute_function=stub_execute,
+        shots=1234,
+        extra_kwarg="forwarded",
+    )
+
+    assert len(execute_calls) == 1
+    received_circuit, received_kwargs = execute_calls[0]
+    assert received_circuit is encoded_circuit
+    assert received_kwargs == {"shots": 1234, "extra_kwarg": "forwarded"}
+
+    assert decode_result_calls == [canned_result]
+    assert data is sentinel


### PR DESCRIPTION
`MSQPAM.decode` called `utils.execute` instead of the `execute_function` supplied by the caller, which was silently ignored.